### PR TITLE
tokenizer - replace stanford tokenizer (gpl) with lucene

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
             <version>18.0</version>
         </dependency>
         <dependency>
-            <groupId>edu.stanford.nlp</groupId>
-            <artifactId>stanford-corenlp</artifactId>
-            <version>3.5.2</version>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+            <version>7.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -52,11 +52,6 @@
             <groupId>org.apache.opennlp</groupId>
             <artifactId>opennlp-tools</artifactId>
             <version>1.5.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.rholder</groupId>
-            <artifactId>snowball-stemmer</artifactId>
-            <version>1.3.0.581.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/bradforj287/SimpleTextSearch/engine/DocumentParser.java
+++ b/src/main/java/com/bradforj287/SimpleTextSearch/engine/DocumentParser.java
@@ -16,6 +16,7 @@ public class DocumentParser {
     private ConcurrentHashMap<String, String> stringPool;
     private boolean useStringPool;
     private boolean parseHtml;
+    TextParseUtils parseUtils = new TextParseUtils();
 
     public DocumentParser(boolean useStringPool, boolean parseHtml) {
         this.useStringPool = useStringPool;
@@ -52,7 +53,7 @@ public class DocumentParser {
         text = text.toLowerCase();
 
         // iterate over parsed terms
-        List<String> terms = TextParseUtils.tokenize(text);
+        List<String> terms = parseUtils.tokenize(text);
 
         List<DocumentTerm> retVal = new ArrayList<>();
         int pos = 0;


### PR DESCRIPTION
this approach uses 2 StandardAnalyzer instances. could use a single one for both indexing and queries. i doubt there's a performance hit - really just a question of coding style